### PR TITLE
More extensible function signatures

### DIFF
--- a/src/chat.test.ts
+++ b/src/chat.test.ts
@@ -6,22 +6,26 @@ import * as replitai from './index';
 test('non streaming chat', async () => {
   const chat = await replitai.chat({
     model: 'chat-bison',
-    context: 'You are a meme bot',
     messages: [{ content: 'what is the meaning of life', author: 'user' }],
+    temperature: 0.5,
+    maxOutputTokens: 1024,
   });
 
   expect(chat.error).toBeFalsy();
   expect(chat.value).toMatchObject({
-    content: expect.any(String),
-    author: expect.any(String),
+    message: {
+      content: expect.any(String),
+      author: expect.any(String),
+    },
   });
 });
 
 test('streaming chat', async () => {
   const chat = await replitai.chatStream({
     model: 'chat-bison',
-    context: 'You are a meme bot',
     messages: [{ content: 'what is the meaning of life', author: 'user' }],
+    temperature: 0.5,
+    maxOutputTokens: 1024,
   });
 
   expect(chat.error).toBeFalsy();
@@ -30,7 +34,7 @@ test('streaming chat', async () => {
     throw new Error('wat');
   }
 
-  for await (const message of chat.value) {
+  for await (const { message } of chat.value) {
     expect(message).toMatchObject({
       content: expect.any(String),
       author: expect.any(String),

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -80,16 +80,16 @@ export async function chat(
     return res;
   }
 
-  const allMessages = await all(res.value);
+  const allResponses = await all(res.value);
 
-  let author = allMessages[0]?.message?.author;
+  let author = allResponses[0]?.message?.author;
   if (!author) {
     author = 'assistant';
   }
 
   return result.Ok({
     message: {
-      content: allMessages.reduce(
+      content: allResponses.reduce(
         (acc, { message: { content } }) => acc + content,
         '',
       ),

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -8,9 +8,6 @@ import makeRequest, { RequestError } from './request';
  */
 export type ChatModel = 'chat-bison';
 
-// Ideally this relationship is inverted, but it makes documentation nicer this way
-const chatModels: Array<ChatModel> = ['chat-bison'];
-
 /**
  * Options for chat request
  * @public
@@ -19,15 +16,7 @@ export interface ChatOptions {
   /**
    * Specifies the model to use
    */
-  model?: ChatModel;
-  /**
-   * Preamble that introduces the conversation context
-   */
-  context?: string;
-  /**
-   * Examples of the conversation context
-   */
-  examples?: Array<ChatMessage>;
+  model: ChatModel;
   /**
    * Previous messages in the conversation
    */
@@ -36,8 +25,15 @@ export interface ChatOptions {
    * Sampling temperature between 0 and 1. The higher the value, the more
    * likely the model will produce a completion that is more creative and
    * imaginative.
+   * Defaults to 0
    */
   temperature?: number;
+  /**
+   * The maximum number of tokens generated in the chat completion.
+   * The absolute maximum value is limited by model's context size.
+   * Defaults to 1024
+   */
+  maxOutputTokens?: number;
 }
 
 /**
@@ -65,7 +61,9 @@ export interface ChatMessage {
  */
 export async function chatStream(
   options: ChatOptions,
-): Promise<result.Result<AsyncGenerator<ChatMessage>, RequestError>> {
+): Promise<
+  result.Result<AsyncGenerator<{ message: ChatMessage }>, RequestError>
+> {
   return chatImpl(options, '/chat_streaming');
 }
 
@@ -75,7 +73,7 @@ export async function chatStream(
  */
 export async function chat(
   options: ChatOptions,
-): Promise<result.Result<ChatMessage, RequestError>> {
+): Promise<result.Result<{ message: ChatMessage }, RequestError>> {
   const res = await chatImpl(options, '/chat');
 
   if (!res.ok) {
@@ -84,14 +82,19 @@ export async function chat(
 
   const allMessages = await all(res.value);
 
-  let author = allMessages[0]?.author;
+  let author = allMessages[0]?.message?.author;
   if (!author) {
     author = 'assistant';
   }
 
   return result.Ok({
-    content: allMessages.reduce((acc, { content }) => acc + content, ''),
-    author,
+    message: {
+      content: allMessages.reduce(
+        (acc, { message: { content } }) => acc + content,
+        '',
+      ),
+      author,
+    },
   });
 }
 
@@ -107,23 +110,25 @@ interface Response {
 async function chatImpl(
   options: ChatOptions,
   urlPath: string,
-): Promise<result.Result<AsyncGenerator<ChatMessage>, RequestError>> {
+): Promise<
+  result.Result<AsyncGenerator<{ message: ChatMessage }>, RequestError>
+> {
   return makeRequest(
     urlPath,
     {
-      model: options.model ?? chatModels[0],
+      model: options.model,
       parameters: {
         prompts: [
           {
-            context: options.context,
-            examples: options.examples,
+            context: '',
             messages: options.messages,
           },
         ],
         temperature: options.temperature,
+        maxOutputTokens: options.maxOutputTokens,
       },
     },
-    (json: Response): ChatMessage => {
+    (json: Response): { message: ChatMessage } => {
       const message = json.responses[0]?.candidates[0]?.message;
 
       if (!message) {
@@ -131,8 +136,10 @@ async function chatImpl(
       }
 
       return {
-        content: message.content,
-        author: message.author,
+        message: {
+          content: message.content,
+          author: message.author,
+        },
       };
     },
   );

--- a/src/completion.test.ts
+++ b/src/completion.test.ts
@@ -2,30 +2,30 @@ import { expect, test } from 'vitest';
 import * as replitai from './index';
 
 test('non streaming completion', async () => {
-  const completion = await replitai.completion({
+  const result = await replitai.completion({
     model: 'text-bison',
     prompt:
       "Here's an essay about why the chicken crossed the road\n # The Chicken and The Road\n",
   });
 
-  expect(completion.error).toBeFalsy();
-  expect(completion.value).toEqual(expect.any(String));
+  expect(result.error).toBeFalsy();
+  expect(result.value?.completion).toEqual(expect.any(String));
 });
 
 test('streaming completion', async () => {
-  const completion = await replitai.completionStream({
+  const result = await replitai.completionStream({
     model: 'text-bison',
     prompt:
       "Here's an essay about why the chicken crossed the road\n # The Chicken and The Road\n",
   });
 
-  expect(completion.error).toBeFalsy();
+  expect(result.error).toBeFalsy();
 
-  if (!completion.ok) {
+  if (!result.ok) {
     throw new Error('wat');
   }
 
-  for await (const message of completion.value) {
-    expect(message).toEqual(expect.any(String));
+  for await (const { completion } of result.value) {
+    expect(completion).toEqual(expect.any(String));
   }
 });

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -8,9 +8,6 @@ import makeRequest, { RequestError } from './request';
  */
 export type CompletionModel = 'text-bison';
 
-// Ideally this relationship is inverted, but it makes documentation nicer this way
-const completionModels = ['text-bison'] as const;
-
 /**
  * Options for completion request
  * @public
@@ -19,7 +16,7 @@ export interface CompletionOptions {
   /**
    * Specifies the model to use
    */
-  model?: CompletionModel;
+  model: CompletionModel;
   /**
    * The string/text to complete
    */
@@ -28,8 +25,15 @@ export interface CompletionOptions {
    * Sampling temperature between 0 and 1. The higher the value, the more
    * likely the model will produce a completion that is more creative and
    * imaginative.
+   * Defaults to 0
    */
   temperature?: number;
+  /**
+   * The maximum number of tokens generated in the completion.
+   * The absolute maximum value is limited by model's context size.
+   * Defaults to 1024
+   */
+  maxOutputTokens?: number;
 }
 
 /**
@@ -38,7 +42,7 @@ export interface CompletionOptions {
  */
 export async function completion(
   options: CompletionOptions,
-): Promise<result.Result<string, RequestError>> {
+): Promise<result.Result<{ completion: string }, RequestError>> {
   const res = await completionImpl(options, '/completion');
 
   if (!res.ok) {
@@ -47,7 +51,9 @@ export async function completion(
 
   const allText = await all(res.value);
 
-  return result.Ok(allText.join(''));
+  return result.Ok({
+    completion: allText.map(({ completion }) => completion).join(''),
+  });
 }
 
 /**
@@ -56,7 +62,9 @@ export async function completion(
  */
 export async function completionStream(
   options: CompletionOptions,
-): Promise<result.Result<AsyncGenerator<string>, RequestError>> {
+): Promise<
+  result.Result<AsyncGenerator<{ completion: string }>, RequestError>
+> {
   return completionImpl(options, '/completion_streaming');
 }
 
@@ -72,23 +80,25 @@ interface Response {
 async function completionImpl(
   options: CompletionOptions,
   urlPath: string,
-): Promise<result.Result<AsyncGenerator<string>, RequestError>> {
+): Promise<
+  result.Result<AsyncGenerator<{ completion: string }>, RequestError>
+> {
   return makeRequest(
     urlPath,
     {
-      model: options.model ?? completionModels[0],
+      model: options.model,
       parameters: {
         prompts: [options.prompt],
       },
     },
-    (json: Response): string => {
+    (json: Response): { completion: string } => {
       const content = json.responses[0]?.choices[0]?.content;
 
       if (typeof content == 'undefined') {
         throw new Error('Expected content');
       }
 
-      return content;
+      return { completion: content };
     },
   );
 }

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -49,10 +49,10 @@ export async function completion(
     return res;
   }
 
-  const allText = await all(res.value);
+  const allResponses = await all(res.value);
 
   return result.Ok({
-    completion: allText.map(({ completion }) => completion).join(''),
+    completion: allResponses.map(({ completion }) => completion).join(''),
   });
 }
 
@@ -89,6 +89,8 @@ async function completionImpl(
       model: options.model,
       parameters: {
         prompts: [options.prompt],
+        temperature: options.temperature,
+        maxOutputTokens: options.maxOutputTokens,
       },
     },
     (json: Response): { completion: string } => {

--- a/src/embedding.test.ts
+++ b/src/embedding.test.ts
@@ -10,7 +10,7 @@ test('embedding', async () => {
   });
 
   expect(completion.error).toBeFalsy();
-  expect(completion.value).toMatchObject({
+  expect(completion.value?.embeddings).toMatchObject({
     values: expect.arrayContaining([expect.any(Number)]),
     truncated: expect.any(Boolean),
   });

--- a/src/embedding.test.ts
+++ b/src/embedding.test.ts
@@ -10,7 +10,7 @@ test('embedding', async () => {
   });
 
   expect(completion.error).toBeFalsy();
-  expect(completion.value?.embeddings).toMatchObject({
+  expect(completion.value?.embedding).toMatchObject({
     values: expect.arrayContaining([expect.any(Number)]),
     truncated: expect.any(Boolean),
   });

--- a/src/embedding.ts
+++ b/src/embedding.ts
@@ -45,7 +45,7 @@ interface Response {
  */
 export async function embedding(
   options: EmbeddingOptions,
-): Promise<result.Result<EmbeddingV, RequestError>> {
+): Promise<result.Result<{ embeddings: EmbeddingV }, RequestError>> {
   const res = await makeRequest(
     '/embedding',
     {
@@ -91,5 +91,5 @@ export async function embedding(
     });
   }
 
-  return result.Ok(e);
+  return result.Ok({ embeddings: e });
 }

--- a/src/embedding.ts
+++ b/src/embedding.ts
@@ -45,7 +45,7 @@ interface Response {
  */
 export async function embedding(
   options: EmbeddingOptions,
-): Promise<result.Result<{ embeddings: EmbeddingV }, RequestError>> {
+): Promise<result.Result<{ embedding: EmbeddingV }, RequestError>> {
   const res = await makeRequest(
     '/embedding',
     {
@@ -91,5 +91,5 @@ export async function embedding(
     });
   }
 
-  return result.Ok({ embeddings: e });
+  return result.Ok({ embedding: e });
 }


### PR DESCRIPTION
# Why

We want to make sure our parameters are more generic as we add more providers. We also want the return types extensible as we expose more complexity.

# What changed

- Return type for completion is an object `{ completion: string }` as opposed to just `string`
- Return type for chat is an object `{ message: Message }` as opposed to just `Message`
- Return type for embedding is an object `{ embedding: Embedding }` as opposed to just `Embedding`

While I'm at it
- Added `maxOutputTokens` option to chat and completion
- Made `model` argument required, no reason for us to fill it for people, we can't have a sane default around this
- Passed `temperature` to the API request, we forgot to do that before

# Test plan

The tests that we have, while somewhat shallow, cover things enough for these changes. Tests pass

(CI is broken because things need to run on Replit, will configure a pipeline that runs CI in Repls)