### PR TITLE
Implement chatMultipleChoices

### DIFF
--- a/src/chat.test.ts
+++ b/src/chat.test.ts
@@ -4,15 +4,15 @@ import { expect, test } from 'vitest';
 import * as replitai from './index';
 
 test('non streaming chat', async () => {
-  const chat = await replitai.chat({
+  const result = await replitai.chat({
     model: 'chat-bison',
     messages: [{ content: 'what is the meaning of life', author: 'user' }],
     temperature: 0.5,
     maxOutputTokens: 1024,
   });
 
-  expect(chat.error).toBeFalsy();
-  expect(chat.value).toMatchObject({
+  expect(result.error).toBeFalsy();
+  expect(result.value).toMatchObject({
     message: {
       content: expect.any(String),
       author: expect.any(String),
@@ -21,23 +21,51 @@ test('non streaming chat', async () => {
 });
 
 test('streaming chat', async () => {
-  const chat = await replitai.chatStream({
+  const result = await replitai.chatStream({
     model: 'chat-bison',
     messages: [{ content: 'what is the meaning of life', author: 'user' }],
     temperature: 0.5,
     maxOutputTokens: 1024,
   });
 
-  expect(chat.error).toBeFalsy();
+  expect(result.error).toBeFalsy();
 
-  if (!chat.ok) {
+  if (!result.ok) {
     throw new Error('wat');
   }
 
-  for await (const { message } of chat.value) {
+  for await (const { message } of result.value) {
     expect(message).toMatchObject({
       content: expect.any(String),
       author: expect.any(String),
     });
   }
+});
+
+test('chat with multiple choices', async () => {
+  const result = await replitai.chatMultipleChoices({
+    model: 'chat-bison',
+    messages: [{ content: 'what is the meaning of life', author: 'user' }],
+    temperature: 0.5,
+    maxOutputTokens: 1024,
+    choicesCount: 4,
+  });
+
+  expect(result.error).toBeFalsy();
+
+  if (!result.ok) {
+    throw new Error('wat');
+  }
+
+  expect(result.value).toMatchObject({
+    choices: expect.arrayContaining([
+      {
+        message: expect.objectContaining({
+          content: expect.any(String),
+          author: expect.any(String),
+        }),
+      },
+    ]),
+  });
+  expect(result.value.choices.length > 1).toBeTruthy();
 });

--- a/src/chat.test.ts
+++ b/src/chat.test.ts
@@ -8,7 +8,7 @@ test('non streaming chat', async () => {
     model: 'chat-bison',
     messages: [{ content: 'what is the meaning of life', author: 'user' }],
     temperature: 0.5,
-    maxOutputTokens: 1024,
+    maxOutputTokens: 128,
   });
 
   expect(result.error).toBeFalsy();
@@ -25,7 +25,7 @@ test('streaming chat', async () => {
     model: 'chat-bison',
     messages: [{ content: 'what is the meaning of life', author: 'user' }],
     temperature: 0.5,
-    maxOutputTokens: 1024,
+    maxOutputTokens: 128,
   });
 
   expect(result.error).toBeFalsy();
@@ -47,7 +47,7 @@ test('chat with multiple choices', async () => {
     model: 'chat-bison',
     messages: [{ content: 'what is the meaning of life', author: 'user' }],
     temperature: 0.5,
-    maxOutputTokens: 1024,
+    maxOutputTokens: 128,
     choicesCount: 4,
   });
 

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -59,7 +59,7 @@ export interface ChatMultipleChoicesOptions extends ChatOptions {
    * Number of chat completions to generate. Minimum 1, the maximum
    * depends on the model, the returned choices will be automatically
    * adjusted to fit the model. You should not treat this as a guarantee,
-   * what you will get is a number of choices upto `choicesCount`.
+   * what you will get is a number of choices up to `choicesCount`.
    */
   choicesCount: number;
 }

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -205,8 +205,6 @@ async function chatImpl(
         throw new Error('Expected at least one message');
       }
 
-      console.log(json.responses[0].candidates.length);
-
       return {
         choices: json.responses[0].candidates.map(({ message }) => ({
           message: {

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -1,6 +1,7 @@
 import all from 'it-all';
 import * as result from './result';
 import makeRequest, { RequestError } from './request';
+import { pipe } from 'it-pipe';
 
 /**
  * Available models for chat completion
@@ -53,6 +54,48 @@ export interface ChatMessage {
   author: string;
 }
 
+export interface ChatMultipleChoicesOptions extends ChatOptions {
+  /**
+   * Number of chat completions to generate. Minimum 1, the maximum
+   * depends on the model, the returned choices will be automatically
+   * adjusted to fit the model. You should not treat this as a guarantee,
+   * what you will get is a number of choices upto `choicesCount`.
+   */
+  choicesCount: number;
+}
+
+/**
+ * Gets multiple chat completions for a single conversation.
+ * The result contains an iterator of messages, please note that this would be
+ * a *single message* that has the contents chunked up.
+ * @public
+ */
+export async function chatMultipleChoices(
+  options: ChatMultipleChoicesOptions,
+): Promise<
+  result.Result<{ choices: Array<{ message: ChatMessage }> }, RequestError>
+> {
+  const res = await chatImpl(options, '/chat');
+
+  if (!res.ok) {
+    return res;
+  }
+
+  const responses = await all(res.value);
+
+  if (responses.length > 1) {
+    throw new Error('Got multiple responses from non-streaming endpoint');
+  }
+
+  const response = responses[0];
+
+  if (!response) {
+    throw new Error('Expected at least one response');
+  }
+
+  return result.Ok(response);
+}
+
 /**
  * Gets a single chat message completion for a conversation.
  * The result contains an iterator of messages, please note that this would be
@@ -64,7 +107,26 @@ export async function chatStream(
 ): Promise<
   result.Result<AsyncGenerator<{ message: ChatMessage }>, RequestError>
 > {
-  return chatImpl(options, '/chat_streaming');
+  const res = await chatImpl(options, '/chat_streaming');
+
+  if (!res.ok) {
+    return res;
+  }
+
+  return result.Ok(
+    pipe(res.value, async function* (source) {
+      for await (const v of source) {
+        const choice = v.choices[0];
+        if (!choice) {
+          throw new Error('Expected at least one choice');
+        }
+
+        yield choice;
+      }
+
+      return;
+    }),
+  );
 }
 
 /**
@@ -80,22 +142,29 @@ export async function chat(
     return res;
   }
 
-  const allResponses = await all(res.value);
+  const responses = await all(res.value);
 
-  let author = allResponses[0]?.message?.author;
-  if (!author) {
-    author = 'assistant';
+  if (responses.length > 1) {
+    throw new Error('Got multiple responses from non-streaming endpoint');
   }
 
-  return result.Ok({
-    message: {
-      content: allResponses.reduce(
-        (acc, { message: { content } }) => acc + content,
-        '',
-      ),
-      author,
-    },
-  });
+  const response = responses[0];
+
+  if (!response) {
+    throw new Error('Expected at least one response');
+  }
+
+  if (response.choices.length > 1) {
+    throw new Error('Got multiple choices without choicesCount');
+  }
+
+  const choice = response.choices[0];
+
+  if (!choice) {
+    throw new Error('Expected at least one choice');
+  }
+
+  return result.Ok(choice);
 }
 
 // non exauhstive
@@ -108,10 +177,13 @@ interface Response {
 }
 
 async function chatImpl(
-  options: ChatOptions,
+  options: ChatOptions | ChatMultipleChoicesOptions,
   urlPath: string,
 ): Promise<
-  result.Result<AsyncGenerator<{ message: ChatMessage }>, RequestError>
+  result.Result<
+    AsyncGenerator<{ choices: Array<{ message: ChatMessage }> }>,
+    RequestError
+  >
 > {
   return makeRequest(
     urlPath,
@@ -126,20 +198,24 @@ async function chatImpl(
         ],
         temperature: options.temperature,
         maxOutputTokens: options.maxOutputTokens,
+        candidateCount:
+          'choicesCount' in options ? options.choicesCount : undefined,
       },
     },
-    (json: Response): { message: ChatMessage } => {
-      const message = json.responses[0]?.candidates[0]?.message;
-
-      if (!message) {
-        throw new Error('Expected message');
+    (json: Response): { choices: Array<{ message: ChatMessage }> } => {
+      if (!json.responses[0]?.candidates[0]?.message) {
+        throw new Error('Expected at least one message');
       }
 
+      console.log(json.responses[0].candidates.length);
+
       return {
-        message: {
-          content: message.content,
-          author: message.author,
-        },
+        choices: json.responses[0].candidates.map(({ message }) => ({
+          message: {
+            content: message.content,
+            author: message.author,
+          },
+        })),
       };
     },
   );

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -65,9 +65,7 @@ export interface ChatMultipleChoicesOptions extends ChatOptions {
 }
 
 /**
- * Gets multiple chat completions for a single conversation.
- * The result contains an iterator of messages, please note that this would be
- * a *single message* that has the contents chunked up.
+ * Gets multiple chat completions for a conversation.
  * @public
  */
 export async function chatMultipleChoices(

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,12 @@
-import { chat, chatStream, ChatOptions, ChatMessage, ChatModel } from './chat';
+import {
+  chat,
+  chatStream,
+  chatMultipleChoices,
+  ChatMultipleChoicesOptions,
+  ChatOptions,
+  ChatMessage,
+  ChatModel,
+} from './chat';
 import {
   completion,
   completionStream,
@@ -14,12 +22,20 @@ import {
   EmbeddingOptions,
 } from './embedding';
 
-export { chat, chatStream, completion, completionStream, embedding };
+export {
+  chat,
+  chatStream,
+  chatMultipleChoices,
+  completion,
+  completionStream,
+  embedding,
+};
 export type {
   Result,
   OkResult,
   ErrResult,
   ChatOptions,
+  ChatMultipleChoicesOptions,
   CompletionOptions,
   ChatMessage,
   CompletionModel,


### PR DESCRIPTION
# Why

We want to provide a way to get multiple choices. The reason it's a separate function instead of turning other methods to allow multiple choices is two folds:

- We think the average user will only want 1 choice
- Google doesn't support streaming with candidates

# What changed

I made the base implementation support multiple choices and other implementations derive from it.

The signature of the function is that it takes in the same chat options with an extra argument for the count and returns an object `{ choices: { message: Message } }`

# Test plan

Added a test