### PR TITLE
Implement completionMultipleChoices

### DIFF
--- a/src/completion.test.ts
+++ b/src/completion.test.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment*/
+
 import { expect, test } from 'vitest';
 import * as replitai from './index';
 
@@ -6,6 +8,8 @@ test('non streaming completion', async () => {
     model: 'text-bison',
     prompt:
       "Here's an essay about why the chicken crossed the road\n # The Chicken and The Road\n",
+    temperature: 0.5,
+    maxOutputTokens: 128,
   });
 
   expect(result.error).toBeFalsy();
@@ -17,6 +21,8 @@ test('streaming completion', async () => {
     model: 'text-bison',
     prompt:
       "Here's an essay about why the chicken crossed the road\n # The Chicken and The Road\n",
+    temperature: 0.5,
+    maxOutputTokens: 128,
   });
 
   expect(result.error).toBeFalsy();
@@ -28,4 +34,30 @@ test('streaming completion', async () => {
   for await (const { completion } of result.value) {
     expect(completion).toEqual(expect.any(String));
   }
+});
+
+test('completion with multiple choices', async () => {
+  const result = await replitai.completionMultipleChoices({
+    model: 'text-bison',
+    prompt:
+      "Here's an essay about why the chicken crossed the road\n # The Chicken and The Road\n",
+    temperature: 0.5,
+    maxOutputTokens: 128,
+    choicesCount: 4,
+  });
+
+  expect(result.error).toBeFalsy();
+
+  if (!result.ok) {
+    throw new Error('wat');
+  }
+
+  expect(result.value).toMatchObject({
+    choices: expect.arrayContaining([
+      {
+        completion: expect.any(String),
+      },
+    ]),
+  });
+  expect(result.value.choices.length > 1).toBeTruthy();
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,9 +9,11 @@ import {
 } from './chat';
 import {
   completion,
+  completionMultipleChoices,
   completionStream,
   CompletionModel,
   CompletionOptions,
+  CompletionMultipleChoicesOptions,
 } from './completion';
 import { Result, OkResult, ErrResult } from './result';
 import { RequestError } from './request';
@@ -28,6 +30,7 @@ export {
   chatMultipleChoices,
   completion,
   completionStream,
+  completionMultipleChoices,
   embedding,
 };
 export type {
@@ -37,6 +40,7 @@ export type {
   ChatOptions,
   ChatMultipleChoicesOptions,
   CompletionOptions,
+  CompletionMultipleChoicesOptions,
   ChatMessage,
   CompletionModel,
   ChatModel,


### PR DESCRIPTION
Same thing as #5 but for completion

The signature of the function is that it takes in the same chat options with an extra argument for the count and returns an object `{ choices: { completion: string } }`