### PR TITLE
Add optional parameters option for chat/completion/embedding.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@replit/ai",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "A library for building AI applications in JavaScript and TypeScript.",
   "homepage": "https://ai-docs-typescript.replit.app/",
   "repository": "https://github.com/replit/replit-ai-typescript",

--- a/src/chat.test.ts
+++ b/src/chat.test.ts
@@ -20,6 +20,28 @@ test('non streaming chat', async () => {
   });
 });
 
+test('non streaming chat with extra parameters', async () => {
+  const result = await replitai.chat({
+    model: 'chat-bison',
+    messages: [{ content: 'What is the meaning of life? ', author: 'user' }],
+    temperature: 0.0,
+    maxOutputTokens: 1024,
+    stopSequences: ['life'],
+  });
+
+  expect(result.error).toBeFalsy();
+  expect(result.value).toMatchObject({
+    message: {
+      content: expect.any(String),
+      author: expect.any(String),
+    },
+  });
+
+  // Check if the message content "life"
+  const messageContent = result.value.message.content;
+  expect(messageContent.includes('life')).toBeFalsy();
+});
+
 test('streaming chat', async () => {
   const result = await replitai.chatStream({
     model: 'chat-bison',

--- a/src/chat.test.ts
+++ b/src/chat.test.ts
@@ -26,7 +26,9 @@ test('non streaming chat with extra parameters', async () => {
     messages: [{ content: 'What is the meaning of life? ', author: 'user' }],
     temperature: 0.0,
     maxOutputTokens: 1024,
-    stopSequences: ['life'],
+    extraParams: {
+      stopSequences: ['life'],
+    },
   });
 
   expect(result.error).toBeFalsy();

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -38,10 +38,10 @@ export interface ChatOptions {
   maxOutputTokens?: number;
 
   /**
-   * Allows extra model specific parameters. Consult with the documentation
+   * Allows extra model specific parameters. Consult with the documentation for which
+   * parameters are available for each model.
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  [key: string]: any;
+  extraParams?: Record<string, unknown>;
 }
 
 /**
@@ -190,30 +190,22 @@ async function chatImpl(
     RequestError
   >
 > {
-  const {
-    model,
-    messages,
-    temperature,
-    maxOutputTokens,
-    choicesCount,
-    ...otherOptions
-  } = options;
-
   return makeRequest(
     urlPath,
     {
-      model: model,
+      model: options.model,
       parameters: {
-        ...otherOptions,
         prompts: [
           {
             context: '',
-            messages,
+            messages: options.messages,
           },
         ],
-        temperature,
-        maxOutputTokens,
-        candidateCount: 'choicesCount' in options ? choicesCount : undefined,
+        temperature: options.temperature,
+        maxOutputTokens: options.maxOutputTokens,
+        candidateCount:
+          'choicesCount' in options ? options.choicesCount : undefined,
+        ...options.extraParams,
       },
     },
     (json: Response): { choices: Array<{ message: ChatMessage }> } => {

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -37,7 +37,9 @@ export interface ChatOptions {
    */
   maxOutputTokens?: number;
 
-  // Allows extra model specific parameters.
+  /**
+   * Allows extra model specific parameters. Consult with the documentation
+   */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any;
 }
@@ -117,7 +119,7 @@ export async function chatStream(
   }
 
   return result.Ok(
-    pipe(res.value, async function* (source) {
+    pipe(res.value, async function (source) {
       for await (const v of source) {
         const choice = v.choices[0];
         if (!choice) {

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -80,7 +80,7 @@ export async function chatMultipleChoices(
 ): Promise<
   result.Result<{ choices: Array<{ message: ChatMessage }> }, RequestError>
 > {
-  const res = await chatImpl(options, '/chat');
+  const res = await chatImpl(options, '/v1beta/chat');
 
   if (!res.ok) {
     return res;
@@ -112,7 +112,7 @@ export async function chatStream(
 ): Promise<
   result.Result<AsyncGenerator<{ message: ChatMessage }>, RequestError>
 > {
-  const res = await chatImpl(options, '/chat_streaming');
+  const res = await chatImpl(options, '/v1beta/chat_streaming');
 
   if (!res.ok) {
     return res;
@@ -141,7 +141,7 @@ export async function chatStream(
 export async function chat(
   options: ChatOptions,
 ): Promise<result.Result<{ message: ChatMessage }, RequestError>> {
-  const res = await chatImpl(options, '/chat');
+  const res = await chatImpl(options, '/v1beta/chat');
 
   if (!res.ok) {
     return res;

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment*/
 import all from 'it-all';
 import * as result from './result';
 import makeRequest, { RequestError } from './request';
@@ -35,6 +36,10 @@ export interface ChatOptions {
    * Defaults to 1024
    */
   maxOutputTokens?: number;
+
+  // Allows extra model specific parameters.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: string]: any;
 }
 
 /**
@@ -183,21 +188,30 @@ async function chatImpl(
     RequestError
   >
 > {
+  const {
+    model,
+    messages,
+    temperature,
+    maxOutputTokens,
+    choicesCount,
+    ...otherOptions
+  } = options;
+
   return makeRequest(
     urlPath,
     {
-      model: options.model,
+      model: model,
       parameters: {
+        ...otherOptions,
         prompts: [
           {
             context: '',
-            messages: options.messages,
+            messages,
           },
         ],
-        temperature: options.temperature,
-        maxOutputTokens: options.maxOutputTokens,
-        candidateCount:
-          'choicesCount' in options ? options.choicesCount : undefined,
+        temperature,
+        maxOutputTokens,
+        candidateCount: 'choicesCount' in options ? choicesCount : undefined,
       },
     },
     (json: Response): { choices: Array<{ message: ChatMessage }> } => {

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -119,7 +119,7 @@ export async function chatStream(
   }
 
   return result.Ok(
-    pipe(res.value, async function (source) {
+    pipe(res.value, async function* (source) {
       for await (const v of source) {
         const choice = v.choices[0];
         if (!choice) {

--- a/src/complete.test.ts
+++ b/src/complete.test.ts
@@ -16,6 +16,22 @@ test('non streaming completion', async () => {
   expect(result.value?.completion).toEqual(expect.any(String));
 });
 
+test('non streaming completion with extra parameters', async () => {
+  const result = await replitai.complete({
+    model: 'text-bison',
+    prompt: 'Complete this sequence up to 10: 1, 2, 3, 4, 5',
+    temperature: 0.5,
+    maxOutputTokens: 128,
+    stopSequences: ['7', '7,'],
+  });
+
+  expect(result.error).toBeFalsy();
+  expect(result.value?.completion).toEqual(expect.any(String));
+
+  expect(result.value?.completion.includes('6')).toBeTruthy();
+  expect(result.value?.completion.includes('7')).toBeFalsy();
+});
+
 test('streaming completion', async () => {
   const result = await replitai.completeStream({
     model: 'text-bison',

--- a/src/complete.test.ts
+++ b/src/complete.test.ts
@@ -22,7 +22,9 @@ test('non streaming completion with extra parameters', async () => {
     prompt: 'Complete this sequence up to 10: 1, 2, 3, 4, 5',
     temperature: 0.5,
     maxOutputTokens: 128,
-    stopSequences: ['7', '7,'],
+    extraParams: {
+      stopSequences: ['7', '7,'],
+    },
   });
 
   expect(result.error).toBeFalsy();

--- a/src/complete.ts
+++ b/src/complete.ts
@@ -136,7 +136,7 @@ export async function completeStream(
   }
 
   return result.Ok(
-    pipe(res.value, async function (source) {
+    pipe(res.value, async function* (source) {
       for await (const v of source) {
         const choice = v.choices[0];
         if (!choice) {

--- a/src/complete.ts
+++ b/src/complete.ts
@@ -35,11 +35,12 @@ export interface CompleteOptions {
    * Defaults to 1024
    */
   maxOutputTokens?: number;
+
   /**
-   * Allows extra model specific parameters. Consult with the documentation
+   * Allows extra model specific parameters. Consult with the documentation for which
+   * parameters are available for each model.
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  [key: string]: any;
+  extraParams?: Record<string, unknown>;
 }
 
 export interface CompleteMultipleChoicesOptions extends CompleteOptions {
@@ -169,27 +170,17 @@ async function completeImpl(
     RequestError
   >
 > {
-  const {
-    model,
-    prompt,
-    temperature,
-    maxOutputTokens,
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-    choicesCount,
-    ...otherOptions
-  } = options;
-
   return makeRequest(
     urlPath,
     {
-      model: model,
+      model: options.model,
       parameters: {
-        ...otherOptions,
-        prompts: [prompt],
-        temperature: temperature,
-        maxOutputTokens: maxOutputTokens,
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        candidateCount: 'choicesCount' in options ? choicesCount : undefined,
+        prompts: [options.prompt],
+        temperature: options.temperature,
+        maxOutputTokens: options.maxOutputTokens,
+        candidateCount:
+          'choicesCount' in options ? options.choicesCount : undefined,
+        ...options.extraParams,
       },
     },
     (json: Response): { choices: Array<{ completion: string }> } => {

--- a/src/complete.ts
+++ b/src/complete.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-assignment*/
 import all from 'it-all';
 import * as result from './result';
 import makeRequest, { RequestError } from './request';
@@ -36,9 +35,9 @@ export interface CompleteOptions {
    * Defaults to 1024
    */
   maxOutputTokens?: number;
-  9;
-
-  // Allows extra model specific parameters.
+  /**
+   * Allows extra model specific parameters. Consult with the documentation
+   */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any;
 }
@@ -137,7 +136,7 @@ export async function completeStream(
   }
 
   return result.Ok(
-    pipe(res.value, async function* (source) {
+    pipe(res.value, async function (source) {
       for await (const v of source) {
         const choice = v.choices[0];
         if (!choice) {
@@ -170,12 +169,12 @@ async function completeImpl(
     RequestError
   >
 > {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const {
     model,
     prompt,
     temperature,
     maxOutputTokens,
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     choicesCount,
     ...otherOptions
   } = options;
@@ -189,6 +188,7 @@ async function completeImpl(
         prompts: [prompt],
         temperature: temperature,
         maxOutputTokens: maxOutputTokens,
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
         candidateCount: 'choicesCount' in options ? choicesCount : undefined,
       },
     },

--- a/src/complete.ts
+++ b/src/complete.ts
@@ -62,7 +62,7 @@ export async function completeMultipleChoices(
 ): Promise<
   result.Result<{ choices: Array<{ completion: string }> }, RequestError>
 > {
-  const res = await completeImpl(options, '/completion');
+  const res = await completeImpl(options, '/v1beta/completion');
 
   if (!res.ok) {
     return res;
@@ -90,7 +90,7 @@ export async function completeMultipleChoices(
 export async function complete(
   options: CompleteOptions,
 ): Promise<result.Result<{ completion: string }, RequestError>> {
-  const res = await completeImpl(options, '/completion');
+  const res = await completeImpl(options, '/v1beta/completion');
 
   if (!res.ok) {
     return res;
@@ -130,7 +130,7 @@ export async function completeStream(
 ): Promise<
   result.Result<AsyncGenerator<{ completion: string }>, RequestError>
 > {
-  const res = await completeImpl(options, '/completion_streaming');
+  const res = await completeImpl(options, '/v1beta/completion_streaming');
 
   if (!res.ok) {
     return res;

--- a/src/complete.ts
+++ b/src/complete.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unsafe-assignment*/
 import all from 'it-all';
 import * as result from './result';
 import makeRequest, { RequestError } from './request';
@@ -35,6 +36,11 @@ export interface CompleteOptions {
    * Defaults to 1024
    */
   maxOutputTokens?: number;
+  9;
+
+  // Allows extra model specific parameters.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: string]: any;
 }
 
 export interface CompleteMultipleChoicesOptions extends CompleteOptions {
@@ -164,16 +170,26 @@ async function completeImpl(
     RequestError
   >
 > {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const {
+    model,
+    prompt,
+    temperature,
+    maxOutputTokens,
+    choicesCount,
+    ...otherOptions
+  } = options;
+
   return makeRequest(
     urlPath,
     {
-      model: options.model,
+      model: model,
       parameters: {
-        prompts: [options.prompt],
-        temperature: options.temperature,
-        maxOutputTokens: options.maxOutputTokens,
-        candidateCount:
-          'choicesCount' in options ? options.choicesCount : undefined,
+        ...otherOptions,
+        prompts: [prompt],
+        temperature: temperature,
+        maxOutputTokens: maxOutputTokens,
+        candidateCount: 'choicesCount' in options ? choicesCount : undefined,
       },
     },
     (json: Response): { choices: Array<{ completion: string }> } => {

--- a/src/embed.ts
+++ b/src/embed.ts
@@ -17,6 +17,10 @@ const embeddingModels = ['textembedding-gecko'] as const;
 export interface EmbedOptions {
   model?: EmbedModel;
   content: string;
+
+  // Allows extra model specific parameters.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  [key: string]: any;
 }
 
 /**
@@ -46,12 +50,14 @@ interface Response {
 export async function embed(
   options: EmbedOptions,
 ): Promise<result.Result<{ embedding: Embedding }, RequestError>> {
+  const { model, content, ...otherOptions } = options;
   const res = await makeRequest(
     '/embedding',
     {
-      model: options.model ?? embeddingModels[0],
+      model: model ?? embeddingModels[0],
       parameters: {
-        content: [{ content: options.content }],
+        ...otherOptions,
+        content: [{ content: content }],
       },
     },
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/embed.ts
+++ b/src/embed.ts
@@ -18,7 +18,9 @@ export interface EmbedOptions {
   model?: EmbedModel;
   content: string;
 
-  // Allows extra model specific parameters.
+  /**
+   * Allows extra model specific parameters. Consult with the documentation
+   */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   [key: string]: any;
 }

--- a/src/embed.ts
+++ b/src/embed.ts
@@ -54,7 +54,7 @@ export async function embed(
 ): Promise<result.Result<{ embedding: Embedding }, RequestError>> {
   const { model, content, ...otherOptions } = options;
   const res = await makeRequest(
-    '/embedding',
+    '/v1beta/embedding',
     {
       model: model ?? embeddingModels[0],
       parameters: {

--- a/src/request/index.ts
+++ b/src/request/index.ts
@@ -21,6 +21,7 @@ export default async function makeRequest<T, R>(
   processJSON: (json: T) => R,
 ): Promise<result.Result<AsyncGenerator<R, void, void>, RequestError>> {
   const url = new URL(version + urlPath, baseUrl);
+
   const response = await fetch(url, {
     method: 'POST',
     headers: {

--- a/src/request/index.ts
+++ b/src/request/index.ts
@@ -13,14 +13,13 @@ export interface RequestError {
 
 const baseUrl =
   process.env.MODEL_FARM_URL ?? 'https://production-modelfarm.replit.com/';
-const version = '/v1beta';
 
 export default async function makeRequest<T, R>(
   urlPath: string,
   body: Record<string, unknown>,
   processJSON: (json: T) => R,
 ): Promise<result.Result<AsyncGenerator<R, void, void>, RequestError>> {
-  const url = new URL(version + urlPath, baseUrl);
+  const url = new URL(urlPath, baseUrl);
 
   const response = await fetch(url, {
     method: 'POST',

--- a/src/request/index.ts
+++ b/src/request/index.ts
@@ -12,15 +12,15 @@ export interface RequestError {
 }
 
 const baseUrl =
-  process.env.MODEL_FARM_URL ?? 'https://production-modelfarm.replit.com/v1beta/';
+  process.env.MODEL_FARM_URL ?? 'https://production-modelfarm.replit.com/';
+const version = '/v1beta';
 
 export default async function makeRequest<T, R>(
   urlPath: string,
   body: Record<string, unknown>,
   processJSON: (json: T) => R,
 ): Promise<result.Result<AsyncGenerator<R, void, void>, RequestError>> {
-  const url = new URL(urlPath, baseUrl);
-
+  const url = new URL(version + urlPath, baseUrl);
   const response = await fetch(url, {
     method: 'POST',
     headers: {

--- a/src/request/index.ts
+++ b/src/request/index.ts
@@ -12,7 +12,7 @@ export interface RequestError {
 }
 
 const baseUrl =
-  process.env.MODEL_FARM_URL ?? 'https://production-modelfarm.replit.com/';
+  process.env.MODEL_FARM_URL ?? 'https://production-modelfarm.replit.com/v1beta/';
 
 export default async function makeRequest<T, R>(
   urlPath: string,


### PR DESCRIPTION
# Why

Some models have extra parameters that we want users to access. 

# What Changed
Added the ability to pass extra parameters to the option classes, that are then included in parameters. This caused some linting issues, which I've disabled for now, but if there's a better way of making these changes, I'm open to making them.

# Testing
Updated unit testing.