### PR TITLE
Move embed to handle batches

### DIFF
--- a/src/embed.test.ts
+++ b/src/embed.test.ts
@@ -6,7 +6,7 @@ import * as replitai from './index';
 test('embedding', async () => {
   const completion = await replitai.embed({
     model: 'textembedding-gecko',
-    content: 'how to quit in vim',
+    content: ['how to quit in vim', 'how to quit in emacs'],
   });
 
   expect(completion.error).toBeFalsy();

--- a/src/embed.test.ts
+++ b/src/embed.test.ts
@@ -3,14 +3,15 @@
 import { expect, test } from 'vitest';
 import * as replitai from './index';
 
-test('embedding', async () => {
+test('embed', async () => {
   const completion = await replitai.embed({
     model: 'textembedding-gecko',
     content: ['how to quit in vim', 'how to quit in emacs'],
   });
 
   expect(completion.error).toBeFalsy();
-  expect(completion.value?.embedding).toMatchObject({
+  expect(completion.value?.embeddings).toHaveLength(2);
+  expect(completion.value?.embeddings[0]).toMatchObject({
     values: expect.arrayContaining([expect.any(Number)]),
     truncated: expect.any(Boolean),
   });

--- a/src/embed.ts
+++ b/src/embed.ts
@@ -16,9 +16,10 @@ export interface EmbedOptions {
    */
   model: EmbedModel;
   /**
-   * The content to embed
+   * The strings to embed, the returned embedding will correspond to the order
+   * of the passed string
    */
-  content: string;
+  content: Array<string>;
 
   /**
    * Allows extra model specific parameters. Consult with the documentation
@@ -58,7 +59,7 @@ export async function embed(
     {
       model: options.model,
       parameters: {
-        content: [{ content: options.content }],
+        content: options.content.map((content) => ({ content })),
         ...options.extraParams,
       },
     },

--- a/src/embed.ts
+++ b/src/embed.ts
@@ -53,7 +53,7 @@ interface Response {
  */
 export async function embed(
   options: EmbedOptions,
-): Promise<result.Result<{ embedding: Embedding }, RequestError>> {
+): Promise<result.Result<{ embeddings: Array<Embedding> }, RequestError>> {
   return makeSimpleRequest(
     '/v1beta/embedding',
     {
@@ -63,19 +63,11 @@ export async function embed(
         ...options.extraParams,
       },
     },
-    (json: Response): { embedding: Embedding } => {
-      const embedding = json.embeddings[0];
-
-      if (!embedding) {
-        throw new Error('Expected embedding');
-      }
-
-      return {
-        embedding: {
-          values: embedding.values,
-          truncated: embedding.truncated,
-        },
-      };
-    },
+    (json: Response): { embeddings: Array<Embedding> } => ({
+      embeddings: json.embeddings.map((embedding) => ({
+        values: embedding.values,
+        truncated: embedding.truncated,
+      })),
+    }),
   );
 }


### PR DESCRIPTION
# Why

All embedding models we aim to support have support for batch embedding requests

# What changed

Made embeds API support batch embedding by passing multiple strings as `content`

# Test plan

Updated the test to match