### PR TITLE
Seperate streaming and non-stream fetch wrappers to simplify

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "eslint": "^8.48.0",
         "eslint-config-prettier": "^9.0.0",
         "eslint-plugin-prettier": "^5.0.0",
-        "it-all": "^3.0.3",
         "it-pipe": "^3.0.1",
         "jest": "^29.6.4",
         "prettier": "^3.0.3",
@@ -4416,12 +4415,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/it-all": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/it-all/-/it-all-3.0.3.tgz",
-      "integrity": "sha512-LwEVD1d0b1O5mDwumnZk+80jSBn5sXDxQ41xiD6j6l2lRiWH6lBLdxXx1C6mlKrXQwRHzUQagOZUmqttDUwb0A==",
-      "dev": true
     },
     "node_modules/it-merge": {
       "version": "3.0.2",
@@ -10367,12 +10360,6 @@
         "html-escaper": "^2.0.0",
         "istanbul-lib-report": "^3.0.0"
       }
-    },
-    "it-all": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/it-all/-/it-all-3.0.3.tgz",
-      "integrity": "sha512-LwEVD1d0b1O5mDwumnZk+80jSBn5sXDxQ41xiD6j6l2lRiWH6lBLdxXx1C6mlKrXQwRHzUQagOZUmqttDUwb0A==",
-      "dev": true
     },
     "it-merge": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "eslint": "^8.48.0",
     "eslint-config-prettier": "^9.0.0",
     "eslint-plugin-prettier": "^5.0.0",
-    "it-all": "^3.0.3",
     "it-pipe": "^3.0.1",
     "jest": "^29.6.4",
     "prettier": "^3.0.3",

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -1,7 +1,9 @@
-import all from 'it-all';
 import * as result from './result';
-import makeRequest, { RequestError } from './request';
-import { pipe } from 'it-pipe';
+import {
+  makeStreamingRequest,
+  makeSimpleRequest,
+  RequestError,
+} from './request';
 
 /**
  * Available models for chat completion
@@ -77,25 +79,20 @@ export async function chatMultipleChoices(
 ): Promise<
   result.Result<{ choices: Array<{ message: ChatMessage }> }, RequestError>
 > {
-  const res = await chatImpl(options, '/v1beta/chat');
+  return makeSimpleRequest(
+    '/v1beta/chat',
+    getRequestOptions(options),
+    processJSON,
+  );
+}
 
-  if (!res.ok) {
-    return res;
-  }
-
-  const responses = await all(res.value);
-
-  if (responses.length > 1) {
-    throw new Error('Got multiple responses from non-streaming endpoint');
-  }
-
-  const response = responses[0];
-
-  if (!response) {
-    throw new Error('Expected at least one response');
-  }
-
-  return result.Ok(response);
+// non exauhstive
+interface RawAPIResponse {
+  responses: Array<{
+    candidates: Array<{
+      message: ChatMessage;
+    }>;
+  }>;
 }
 
 /**
@@ -109,25 +106,20 @@ export async function chatStream(
 ): Promise<
   result.Result<AsyncGenerator<{ message: ChatMessage }>, RequestError>
 > {
-  const res = await chatImpl(options, '/v1beta/chat_streaming');
+  return makeStreamingRequest(
+    '/v1beta/chat_streaming',
+    getRequestOptions(options),
+    (json: RawAPIResponse) => {
+      const { choices } = processJSON(json);
 
-  if (!res.ok) {
-    return res;
-  }
+      const choice = choices[0];
 
-  return result.Ok(
-    pipe(res.value, async function* (source) {
-      for await (const v of source) {
-        const choice = v.choices[0];
-        if (!choice) {
-          throw new Error('Expected at least one choice');
-        }
-
-        yield choice;
+      if (!choice) {
+        throw new Error('Expected at least one choice');
       }
 
-      return;
-    }),
+      return choice;
+    },
   );
 }
 
@@ -138,29 +130,21 @@ export async function chatStream(
 export async function chat(
   options: ChatOptions,
 ): Promise<result.Result<{ message: ChatMessage }, RequestError>> {
-  const res = await chatImpl(options, '/v1beta/chat');
+  const res = await makeSimpleRequest(
+    '/v1beta/chat',
+    getRequestOptions(options),
+    processJSON,
+  );
 
   if (!res.ok) {
     return res;
   }
 
-  const responses = await all(res.value);
-
-  if (responses.length > 1) {
-    throw new Error('Got multiple responses from non-streaming endpoint');
-  }
-
-  const response = responses[0];
-
-  if (!response) {
-    throw new Error('Expected at least one response');
-  }
-
-  if (response.choices.length > 1) {
+  if (res.value.choices.length > 1) {
     throw new Error('Got multiple choices without choicesCount');
   }
 
-  const choice = response.choices[0];
+  const choice = res.value.choices[0];
 
   if (!choice) {
     throw new Error('Expected at least one choice');
@@ -169,55 +153,42 @@ export async function chat(
   return result.Ok(choice);
 }
 
-// non exauhstive
-interface Response {
-  responses: Array<{
-    candidates: Array<{
-      message: ChatMessage;
-    }>;
-  }>;
+
+
+function getRequestOptions(
+  options: ChatOptions | ChatMultipleChoicesOptions,
+): Record<string, unknown> {
+  return {
+    model: options.model,
+    parameters: {
+      prompts: [
+        {
+          context: '',
+          messages: options.messages,
+        },
+      ],
+      temperature: options.temperature,
+      maxOutputTokens: options.maxOutputTokens,
+      candidateCount:
+        'choicesCount' in options ? options.choicesCount : undefined,
+      ...options.extraParams,
+    },
+  };
 }
 
-async function chatImpl(
-  options: ChatOptions | ChatMultipleChoicesOptions,
-  urlPath: string,
-): Promise<
-  result.Result<
-    AsyncGenerator<{ choices: Array<{ message: ChatMessage }> }>,
-    RequestError
-  >
-> {
-  return makeRequest(
-    urlPath,
-    {
-      model: options.model,
-      parameters: {
-        prompts: [
-          {
-            context: '',
-            messages: options.messages,
-          },
-        ],
-        temperature: options.temperature,
-        maxOutputTokens: options.maxOutputTokens,
-        candidateCount:
-          'choicesCount' in options ? options.choicesCount : undefined,
-        ...options.extraParams,
-      },
-    },
-    (json: Response): { choices: Array<{ message: ChatMessage }> } => {
-      if (!json.responses[0]?.candidates[0]?.message) {
-        throw new Error('Expected at least one message');
-      }
+function processJSON(json: RawAPIResponse): {
+  choices: Array<{ message: ChatMessage }>;
+} {
+  if (!json.responses[0]?.candidates[0]?.message) {
+    throw new Error('Expected at least one message');
+  }
 
-      return {
-        choices: json.responses[0].candidates.map(({ message }) => ({
-          message: {
-            content: message.content,
-            author: message.author,
-          },
-        })),
-      };
-    },
-  );
+  return {
+    choices: json.responses[0].candidates.map(({ message }) => ({
+      message: {
+        content: message.content,
+        author: message.author,
+      },
+    })),
+  };
 }

--- a/src/chat.ts
+++ b/src/chat.ts
@@ -153,8 +153,6 @@ export async function chat(
   return result.Ok(choice);
 }
 
-
-
 function getRequestOptions(
   options: ChatOptions | ChatMultipleChoicesOptions,
 ): Record<string, unknown> {

--- a/src/complete.ts
+++ b/src/complete.ts
@@ -134,8 +134,6 @@ export async function completeStream(
   );
 }
 
-
-
 function getRequestOptions(
   options: CompleteOptions | CompleteMultipleChoicesOptions,
 ): Record<string, unknown> {
@@ -151,7 +149,6 @@ function getRequestOptions(
     },
   };
 }
-
 
 function processJSON(json: RawAPIResponse): {
   choices: Array<{ completion: string }>;

--- a/src/request/handleStreamingResponseBody.ts
+++ b/src/request/handleStreamingResponseBody.ts
@@ -2,7 +2,7 @@ import { pipe } from 'it-pipe';
 import streamToIterator from 'browser-readablestream-to-it';
 import IncrementalJSONParser from './incrementalJSONParser';
 
-export default function responseBodyToIterator<T, R>(
+export default function handleStreamingResponseBody<T, R>(
   responseBody: ReadableStream<Uint8Array>,
   processJSON: (json: T) => R,
 ): AsyncGenerator<R> {

--- a/src/request/index.ts
+++ b/src/request/index.ts
@@ -49,11 +49,9 @@ export async function doFetch(
   }
 
   return result.Ok(
-    response as Response & { body: NonNullable<Response['body']>; }
+    response as Response & { body: NonNullable<Response['body']> },
   );
 }
-
-
 
 export async function makeStreamingRequest<T, R>(
   urlPath: string,

--- a/src/request/index.ts
+++ b/src/request/index.ts
@@ -1,6 +1,6 @@
 import * as result from '../result';
 import getToken from './getToken';
-import responseBodyToIterator from './responseBodyToIterator';
+import handleStreamingResponseBody from './handleStreamingResponseBody';
 
 /**
  * An object that represents an error with a request
@@ -11,14 +11,18 @@ export interface RequestError {
   statusCode: number;
 }
 
-const baseUrl =
+export const baseUrl =
   process.env.MODEL_FARM_URL ?? 'https://production-modelfarm.replit.com/';
 
-export default async function makeRequest<T, R>(
+export async function doFetch(
   urlPath: string,
   body: Record<string, unknown>,
-  processJSON: (json: T) => R,
-): Promise<result.Result<AsyncGenerator<R, void, void>, RequestError>> {
+): Promise<
+  result.Result<
+    Response & { body: NonNullable<Response['body']> },
+    RequestError
+  >
+> {
   const url = new URL(urlPath, baseUrl);
 
   const response = await fetch(url, {
@@ -44,7 +48,41 @@ export default async function makeRequest<T, R>(
     });
   }
 
-  const iterator = responseBodyToIterator(response.body, processJSON);
+  return result.Ok(
+    response as Response & { body: NonNullable<Response['body']>; }
+  );
+}
+
+
+
+export async function makeStreamingRequest<T, R>(
+  urlPath: string,
+  body: Record<string, unknown>,
+  processJSON: (json: T) => R,
+): Promise<result.Result<AsyncGenerator<R, void, void>, RequestError>> {
+  const res = await doFetch(urlPath, body);
+
+  if (!res.ok) {
+    return res;
+  }
+
+  const iterator = handleStreamingResponseBody(res.value.body, processJSON);
 
   return result.Ok(iterator);
+}
+
+export async function makeSimpleRequest<T, R>(
+  urlPath: string,
+  body: Record<string, unknown>,
+  processJSON: (json: T) => R,
+): Promise<result.Result<R, RequestError>> {
+  const res = await doFetch(urlPath, body);
+
+  if (!res.ok) {
+    return res;
+  }
+
+  const json = (await res.value.json()) as T;
+
+  return result.Ok(processJSON(json));
 }


### PR DESCRIPTION
# Why

There was lots of extra logic around unstreamifying responses that are already not a stream.

# What changed

Expose 2 new internal helpers `makeStreamingRequest` and `makeSimpleRequest` to replace the singular `makeRequest` which was centered around streaming and lead us to do iterator gymnaistics to handle simple requests.

# Test plan

Tests pass